### PR TITLE
Do not print trailing column if no error message

### DIFF
--- a/errs.go
+++ b/errs.go
@@ -163,11 +163,11 @@ func (e *errorT) Format(f fmt.State, c rune) {
 			fmt.Fprint(f, name)
 		}
 	}
-	if len(e.err.Error()) > 0 {
+	if text := e.err.Error(); len(text) > 0 {
 		if printSeparator {
 			fmt.Fprint(f, ": ")
 		}
-		fmt.Fprintf(f, "%v", e.err)
+		fmt.Fprintf(f, "%v", text)
 	}
 
 	if f.Flag(int('+')) {

--- a/errs.go
+++ b/errs.go
@@ -152,13 +152,23 @@ func (e *errorT) Error() string {
 // Format handles the formatting of the error. Using a "+" on the format string
 // specifier will also write the stack trace.
 func (e *errorT) Format(f fmt.State, c rune) {
+	var printSeparator bool
 	for i := len(e.classes) - 1; i >= 0; i-- {
 		name := string(*e.classes[i])
 		if len(name) > 0 {
-			fmt.Fprintf(f, "%s: ", name)
+			if printSeparator {
+				fmt.Fprint(f, ": ")
+			}
+			printSeparator = true
+			fmt.Fprint(f, name)
 		}
 	}
-	fmt.Fprintf(f, "%v", e.err)
+	if len(e.err.Error()) > 0 {
+		if printSeparator {
+			fmt.Fprint(f, ": ")
+		}
+		fmt.Fprintf(f, "%v", e.err)
+	}
 
 	if f.Flag(int('+')) {
 		summarizeStack(f, e.pcs)

--- a/errs_test.go
+++ b/errs_test.go
@@ -153,5 +153,10 @@ func TestErrs(t *testing.T) {
 			assert(t, empty.New("test").Error() == "test")
 			assert(t, foo.Wrap(empty.New("test")).Error() == "foo: test")
 		})
+
+		t.Run("Empty Format", func(t *testing.T) {
+			assert(t, empty.New("").Error() == "")
+			assert(t, foo.New("").Error() == "foo")
+		})
 	})
 }


### PR DESCRIPTION
Sometimes errors are created without a message, e.g.:

```go
var NoKeyError = errs.Class("missing key")

err := NoKeyError.New("")
```

In such case a trailing column should not be printed when printing the error, i.e. we should have:
```
missing key
```
instead of:
```
missing key: 
```