### PR TITLE
Add IsFunc function

### DIFF
--- a/errs.go
+++ b/errs.go
@@ -95,10 +95,6 @@ func Classes(err error) (classes []*Class) {
 
 // IsFunc checks if any of the underlying errors matches the func
 func IsFunc(err error, is func(err error) bool) bool {
-	if err == nil {
-		return is(err)
-	}
-
 	causes := 0
 	errs := []error{err}
 

--- a/errs.go
+++ b/errs.go
@@ -111,7 +111,12 @@ func IsFunc(err error, is func(err error) bool) bool {
 
 			switch e := err.(type) {
 			case ungrouper:
-				next = append(next, e.Ungroup()...)
+				ungrouped := e.Ungroup()
+				for _, unerr := range ungrouped {
+					if unerr != nil {
+						next = append(next, unerr)
+					}
+				}
 			case Causer:
 				cause := e.Cause()
 				if cause != nil && cause != err {

--- a/errs.go
+++ b/errs.go
@@ -124,10 +124,10 @@ func IsFunc(err error, is func(err error) bool) bool {
 				}
 			}
 
-			causes++
 			if causes >= maxCause {
 				return false
 			}
+			causes++
 		}
 		errs = next
 	}

--- a/errs.go
+++ b/errs.go
@@ -115,12 +115,12 @@ func IsFunc(err error, is func(err error) bool) bool {
 				}
 			case Causer:
 				cause := e.Cause()
-				if cause != nil && cause != err {
+				if cause != nil {
 					next = append(next, cause)
 				}
 			case unwrapper:
 				unwrapped := e.Unwrap()
-				if unwrapped != nil && unwrapped != err {
+				if unwrapped != nil {
 					next = append(next, unwrapped)
 				}
 			}

--- a/errs.go
+++ b/errs.go
@@ -20,6 +20,10 @@ type Causer interface{ Cause() error }
 // the underlying cause of the error, or nil if there is no underlying error.
 type unwrapper interface{ Unwrap() error }
 
+// ungrouper is implemented by combinedError returned in this package. It
+// returns all underlying errors, or nil if there is no underlying error.
+type ungrouper interface{ Ungroup() []error }
+
 // New returns an error not contained in any class. This is the same as calling
 // fmt.Errorf(...) except it captures a stack trace on creation.
 func New(format string, args ...interface{}) error {
@@ -87,6 +91,48 @@ func Classes(err error) (classes []*Class) {
 		}
 		causes++
 	}
+}
+
+// IsFunc checks if any of the underlying errors matches the func
+func IsFunc(err error, is func(err error) bool) bool {
+	if err == nil {
+		return is(err)
+	}
+
+	causes := 0
+	errs := []error{err}
+
+	for len(errs) > 0 {
+		var next []error
+		for _, err := range errs {
+			if is(err) {
+				return true
+			}
+
+			switch e := err.(type) {
+			case ungrouper:
+				next = append(next, e.Ungroup()...)
+			case Causer:
+				cause := e.Cause()
+				if cause != nil && cause != err {
+					next = append(next, cause)
+				}
+			case unwrapper:
+				unwrapped := e.Unwrap()
+				if unwrapped != nil && unwrapped != err {
+					next = append(next, unwrapped)
+				}
+			}
+
+			causes++
+			if causes >= maxCause {
+				return false
+			}
+		}
+		errs = next
+	}
+
+	return false
 }
 
 //

--- a/errs_test.go
+++ b/errs_test.go
@@ -137,6 +137,48 @@ func TestErrs(t *testing.T) {
 			assert(t, classes[1] == &foo)
 		})
 
+		t.Run("IsFunc", func(t *testing.T) {
+			alpha := New("alpha")
+			beta := New("beta")
+			gamma := New("gamma")
+			delta := New("delta")
+			epsilon := New("epsilon")
+
+			assert(t, IsFunc(nil, func(err error) bool {
+				return err == nil
+			}))
+			assert(t, !IsFunc(nil, func(err error) bool {
+				return err == alpha
+			}))
+			assert(t, IsFunc(alpha, func(err error) bool {
+				return err == alpha
+			}))
+			assert(t, !IsFunc(alpha, func(err error) bool {
+				return err == beta
+			}))
+
+			err := Combine(
+				alpha,
+				foo.Wrap(bar.Wrap(baz.Wrap(beta))),
+				bar.Wrap(Combine(gamma, baz.Wrap(delta))),
+			)
+			assert(t, IsFunc(err, func(err error) bool {
+				return err == alpha
+			}))
+			assert(t, IsFunc(err, func(err error) bool {
+				return err == beta
+			}))
+			assert(t, IsFunc(err, func(err error) bool {
+				return err == gamma
+			}))
+			assert(t, IsFunc(err, func(err error) bool {
+				return err == delta
+			}))
+			assert(t, !IsFunc(err, func(err error) bool {
+				return err == epsilon
+			}))
+		})
+
 		t.Run("Name", func(t *testing.T) {
 			name, ok := New("t").(Namer).Name()
 			assert(t, !ok)

--- a/group.go
+++ b/group.go
@@ -69,6 +69,11 @@ func (group combinedError) Unwrap() error {
 	return group.Cause()
 }
 
+// Ungroup returns all errors.
+func (group combinedError) Ungroup() []error {
+	return group
+}
+
 // Error returns error string delimited by semicolons.
 func (group combinedError) Error() string { return fmt.Sprintf("%v", group) }
 


### PR DESCRIPTION
Adds `errs.IsFunc` function that checks if any of the underlying errors matches the given function. It traverses the complete error tree (up to `maxCause` nodes) in the case of combined errors.