### PR TITLE
Add Is function

### DIFF
--- a/errs.go
+++ b/errs.go
@@ -102,6 +102,13 @@ func Classes(err error) (classes []*Class) {
 	}
 }
 
+// Is checks if any of the underlying errors matches target
+func Is(err, target error) bool {
+	return IsFunc(err, func(err error) bool {
+		return err == target
+	})
+}
+
 // IsFunc checks if any of the underlying errors matches the func
 func IsFunc(err error, is func(err error) bool) bool {
 	causes := 0

--- a/errs_test.go
+++ b/errs_test.go
@@ -151,6 +151,30 @@ func TestErrs(t *testing.T) {
 			assert(t, classes[1] == &foo)
 		})
 
+		t.Run("Is", func(t *testing.T) {
+			alpha := New("alpha")
+			beta := New("beta")
+			gamma := New("gamma")
+			delta := New("delta")
+			epsilon := New("epsilon")
+
+			assert(t, Is(nil, nil))
+			assert(t, !Is(nil, alpha))
+			assert(t, Is(alpha, alpha))
+			assert(t, !Is(alpha, beta))
+
+			err := Combine(
+				alpha,
+				foo.Wrap(bar.Wrap(baz.Wrap(beta))),
+				bar.Wrap(Combine(gamma, baz.Wrap(delta))),
+			)
+			assert(t, Is(err, alpha))
+			assert(t, Is(err, beta))
+			assert(t, Is(err, gamma))
+			assert(t, Is(err, delta))
+			assert(t, !Is(err, epsilon))
+		})
+
 		t.Run("IsFunc", func(t *testing.T) {
 			alpha := New("alpha")
 			beta := New("beta")


### PR DESCRIPTION
Adds `errs.Is` function that checks if any of the underlying errors matches the given target error. It uses `IsFunc` from #7 to traverse the error tree.

Compared to `IsFunc`, `Is` allows more readable code when the checks are simple.

Compare:
```go
if errs.Is(err, io.EOF) {
	// do something
}
```
to
```go
if errs.IsFunc(err, func(err error) bool {
	return err == io.EOF
}) {
	// do something
}
```