### PR TITLE
restore API backward compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Egon Elbre <github.com/egonelbre>
 Jeff Wendling <leterip@gmail.com>
 JT Olio <github.com/jtolds>
 Kaloyan Raev <github.com/kaloyan-raev>
+paul cannon <github.com/thepaul>

--- a/is_go_other.go
+++ b/is_go_other.go
@@ -1,8 +1,17 @@
 //go:build !go1.20
+// +build !go1.20
 
 package errs
 
 // Is checks if any of the underlying errors matches target
 func Is(err, target error) bool {
-	return IsFunc(err, func(err error) bool { return err == target })
+	return IsFunc(err, func(err error) bool {
+		if err == target {
+			return true
+		}
+		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+			return true
+		}
+		return false
+	})
 }


### PR DESCRIPTION
This restores the Causer and ungrouper interfaces and support for them, because someone might have code using them already.

Also, this makes errs.Is() work (almost) the same when building with go < 1.20 as it does when building with go 1.20. To be specific, this adds support for the `err.Is(target)` idiom.