### PR TITLE
support errors.Is(err, MyClass.Instance())

### DIFF
--- a/errs_test.go
+++ b/errs_test.go
@@ -70,6 +70,26 @@ func TestErrs(t *testing.T) {
 			t.Logf("%+v", err)
 			assert(t, foo.Has(err))
 		})
+
+		t.Run("Instance", func(t *testing.T) {
+			assert(t, errors.Is(foo.New("t"), foo.Instance()))
+			assert(t, !errors.Is(bar.New("t"), foo.Instance()))
+			assert(t, !errors.Is(baz.New("t"), foo.Instance()))
+
+			assert(t, !errors.Is(foo.New("t"), bar.Instance()))
+			assert(t, errors.Is(bar.New("t"), bar.Instance()))
+			assert(t, !errors.Is(baz.New("t"), bar.Instance()))
+
+			assert(t, errors.Is(bar.Wrap(foo.New("t")), foo.Instance()))
+			assert(t, errors.Is(bar.Wrap(foo.New("t")), bar.Instance()))
+			assert(t, !errors.Is(bar.Wrap(foo.New("t")), baz.Instance()))
+
+			assert(t, errors.Is(foo.Wrap(bar.New("t")), foo.Instance()))
+			assert(t, errors.Is(foo.Wrap(bar.New("t")), bar.Instance()))
+			assert(t, !errors.Is(foo.Wrap(bar.New("t")), baz.Instance()))
+
+			assert(t, !errors.Is(fmt.Errorf("non-zeebo-errs error"), foo.Instance()))
+		})
 	})
 
 	t.Run("Error", func(t *testing.T) {


### PR DESCRIPTION
The MyClass.Has(err) idiom has never been anyone's favorite thing. It was a necessary compromise given what was available to us at the time. But with the help of errors.Is(), maybe something like this is better?

    MyClass := errs.Class("foo")
    err := MyClass.Wrap(io.EOF)
    if errors.Is(err, MyClass.Instance()) {
        fmt.Println("err is an instance of MyClass")
    }

It's still a little clunky, since we have to have the .Instance() method there at all. I think it's necessary to avoid having Class implement the error interface itself, and I think that's always been an anti-goal.

Suggestions welcome for a better name.